### PR TITLE
Update uair config

### DIFF
--- a/kc868-uair.yaml
+++ b/kc868-uair.yaml
@@ -1,6 +1,12 @@
-esphome:
+substitutions:
   name: kc868-uair
-  platform: ESP32
+  dallas_address: "0xC000000004D81528"
+
+esphome:
+  name: ${name}
+  name_add_mac_suffix: true
+  
+esp32:
   board: esp32dev
 
 web_server:
@@ -16,13 +22,11 @@ logger:
 api:
 
 ota:
-  password: ""
 
 wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "KC868-Uair Fallback Hotspot"
-    password: ""
 
 captive_portal:
 
@@ -41,7 +45,7 @@ dallas:
 # Individual sensors
 sensor:
   - platform: dallas
-    address: 0xC000000004D81528 # your DS18B20 address
+    address: $dallas_address # your DS18B20 address
     name: "internal Temperature"
 
   # Example configuration entry

--- a/kc868-uair.yaml
+++ b/kc868-uair.yaml
@@ -6,6 +6,10 @@ esphome:
   name: ${name}
   name_add_mac_suffix: true
   
+  project:
+    name: kincony.kc686-uair
+    version: "1"
+  
 esp32:
   board: esp32dev
 


### PR DESCRIPTION
- This allows the adopted device to override the `name` easily:
  ```yaml
  substitutions:
    name: kc868-uair
  ```

- This is just a tidy up of the config to utilise more modern ESPHome platforms, utilise the `name` `substitution` and add the mac address to the `name` of the device:
  ```yaml
  esphome:
    name: ${name}
    name_add_mac_suffix: true

  esp32:
    board: esp32dev
  ```

- This identifies the project to the `dashboard_import`/adoption process and shows in the ESPHome when it is discovered.
  ```yaml
  esphome:
    ...
    project:
      name: kincony.kc686-uair
      version: "1"
  ```

- This utilizes the `dallas_address` `substitution` that the user can set in their own adopted YAML to override the default one here:
  ```yaml
  sensor:
    - platform: dallas
      address: $dallas_address
  ```